### PR TITLE
Used Objects.hash in hashCode implementation inside PairOfStrings

### DIFF
--- a/lintools-datatypes/src/main/java/tl/lin/data/pair/PairOfStrings.java
+++ b/lintools-datatypes/src/main/java/tl/lin/data/pair/PairOfStrings.java
@@ -19,6 +19,7 @@ package tl.lin.data.pair;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Objects;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
@@ -153,7 +154,7 @@ public class PairOfStrings implements WritableComparable<PairOfStrings> {
    * @return hash code for the pair
    */
   public int hashCode() {
-    return leftElement.hashCode() + rightElement.hashCode();
+    return Objects.hash(leftElement, rightElement);
   }
 
   /**

--- a/lintools-datatypes/src/test/java/tl/lin/data/pair/PairOfStringsTest.java
+++ b/lintools-datatypes/src/test/java/tl/lin/data/pair/PairOfStringsTest.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.HashSet;
 
 import junit.framework.JUnit4TestAdapter;
 
@@ -141,6 +142,24 @@ public class PairOfStringsTest {
     assertTrue(WritableComparatorTestHarness.compare(comparator, pair1, pair5) < 0);
     assertTrue(WritableComparatorTestHarness.compare(comparator, pair3, pair4) > 0);
     assertTrue(WritableComparatorTestHarness.compare(comparator, pair4, pair5) < 0);
+  }
+
+  @Test
+  public void testHashCode() throws IOException {
+    PairOfStrings pair1 = new PairOfStrings("hi", "there");
+    PairOfStrings pair2 = new PairOfStrings("there", "hi");
+    PairOfStrings pair3 = new PairOfStrings("hello", "world");
+
+    HashSet<PairOfStrings> hash = new HashSet<PairOfStrings>();
+
+    assertTrue(hash.add(pair1));
+    assertFalse(hash.add(pair1));
+    assertTrue(hash.add(pair2));
+    assertFalse(hash.add(pair2));
+    assertTrue(hash.add(pair3));
+    assertTrue(hash.remove(pair3));
+    assertTrue(hash.remove(pair1));
+    assertTrue(hash.remove(pair2));
   }
 
   public static junit.framework.Test suite() {


### PR DESCRIPTION
If you create a HashSet of PairOfStrings objects, and add `(x, y)` into the set, and then try to add `(y, x)` into the set, it doesn't work. PairOfStrings objects are supposed to behave like tuples, so semantically `(x, y)` should be different from `(y, x)`, and because of that I should be able to add both `(x, y)` and `(y, x)` separately into a HashSet. The `hashCode` function that makes all this work is using a commutative operation to determine an object's hash. This PR changes it to use [`Objects.hash`](http://docs.oracle.com/javase/7/docs/api/java/util/Objects.html#hash(java.lang.Object...)), a non-commutative operation.