### PR TITLE
Upgraded dependencies in lintools-datatypes-fastutil fixed broken tests.

### DIFF
--- a/lintools-datatypes-fastutil/pom.xml
+++ b/lintools-datatypes-fastutil/pom.xml
@@ -27,15 +27,9 @@
     <developer>
       <id>lintool</id>
       <name>Jimmy Lin</name>
-      <email>jimmylin@umd.edu</email>
+      <email>jimmylin@uwaterloo.ca</email>
     </developer>
   </developers>
-
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
 
   <distributionManagement>
     <snapshotRepository>
@@ -63,12 +57,29 @@
     </repository>
   </repositories>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <testSource>1.8</testSource>
+          <testTarget>1.8</testTarget>
+          <showDeprecation>true</showDeprecation>
+          <compilerArgument>-Xlint:unchecked</compilerArgument>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
+        <version>1.6.8</version>
         <extensions>true</extensions>
         <configuration>
           <serverId>ossrh</serverId>
@@ -79,7 +90,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -93,7 +104,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -106,7 +117,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.0.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -129,7 +140,7 @@
     <dependency>
       <groupId>tl.lin</groupId>
       <artifactId>lintools-datatypes</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.1</version>
       <type>test-jar</type>
       <scope>test</scope>
       <optional>true</optional>
@@ -137,7 +148,7 @@
     <dependency>
       <groupId>tl.lin</groupId>
       <artifactId>lintools-datatypes</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.1</version>
     </dependency>
     <dependency>
       <groupId>it.unimi.dsi</groupId>
@@ -158,7 +169,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
-      <version>2.5.0-cdh5.2.1</version>
+      <version>3.1.0</version>
       <optional>true</optional>
     </dependency>
   </dependencies>

--- a/lintools-datatypes-fastutil/src/test/java/tl/lin/data/map/Int2FloatOpenHashMapWritableTest.java
+++ b/lintools-datatypes-fastutil/src/test/java/tl/lin/data/map/Int2FloatOpenHashMapWritableTest.java
@@ -16,17 +16,16 @@
 
 package tl.lin.data.map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import it.unimi.dsi.fastutil.ints.Int2FloatMap;
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
-import junit.framework.JUnit4TestAdapter;
-
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class Int2FloatOpenHashMapWritableTest {
 
@@ -133,6 +132,8 @@ public class Int2FloatOpenHashMapWritableTest {
 
     value = m2.get(4);
     assertEquals(22.0f, value, 10e-6);
+
+    Int2FloatOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test
@@ -172,6 +173,8 @@ public class Int2FloatOpenHashMapWritableTest {
 
     value = m3.get(4);
     assertEquals(22.0f, value, 10e-6);
+
+    Int2FloatOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test
@@ -279,6 +282,8 @@ public class Int2FloatOpenHashMapWritableTest {
     assertEquals(9.0f, m1.get(1), 10e-6);
     assertEquals(22.0f, m1.get(2), 10e-6);
     assertEquals(5.0f, m1.get(3), 10e-6);
+
+    Int2FloatOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test

--- a/lintools-datatypes-fastutil/src/test/java/tl/lin/data/map/Int2IntOpenHashMapWritableTest.java
+++ b/lintools-datatypes-fastutil/src/test/java/tl/lin/data/map/Int2IntOpenHashMapWritableTest.java
@@ -16,17 +16,16 @@
 
 package tl.lin.data.map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import it.unimi.dsi.fastutil.ints.Int2IntMap;
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
-import junit.framework.JUnit4TestAdapter;
-
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class Int2IntOpenHashMapWritableTest {
 
@@ -133,6 +132,8 @@ public class Int2IntOpenHashMapWritableTest {
 
     value = m2.get(4);
     assertEquals(22, value);
+
+    Int2IntOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test
@@ -143,12 +144,10 @@ public class Int2IntOpenHashMapWritableTest {
     m1.put(3, 5);
     m1.put(4, 22);
 
-    // Object m2 should not have been decoded, size lazy decode flag is
-    // true.
+    // Object m2 should not have been decoded, size lazy decode flag is true.
     Int2IntOpenHashMapWritable m2 = Int2IntOpenHashMapWritable.create(m1.serialize());
 
-    // Even though m2 hasn't be decoded, we should be able to properly
-    // serialize it.
+    // Even though m2 hasn't be decoded, we should be able to properly serialize it.
     Int2IntOpenHashMapWritable m3 = Int2IntOpenHashMapWritable.create(m2.serialize());
 
     assertEquals(0, m3.size());
@@ -174,6 +173,8 @@ public class Int2IntOpenHashMapWritableTest {
 
     value = m3.get(4);
     assertEquals(22, value);
+
+    Int2IntOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test
@@ -279,6 +280,8 @@ public class Int2IntOpenHashMapWritableTest {
     assertEquals(9, m1.get(1));
     assertEquals(22, m1.get(2));
     assertEquals(5, m1.get(3));
+
+    Int2IntOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test

--- a/lintools-datatypes-fastutil/src/test/java/tl/lin/data/map/Int2LongOpenHashMapWritableTest.java
+++ b/lintools-datatypes-fastutil/src/test/java/tl/lin/data/map/Int2LongOpenHashMapWritableTest.java
@@ -16,17 +16,16 @@
 
 package tl.lin.data.map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import it.unimi.dsi.fastutil.ints.Int2LongMap;
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Random;
 
-import junit.framework.JUnit4TestAdapter;
-
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class Int2LongOpenHashMapWritableTest {
 
@@ -137,6 +136,8 @@ public class Int2LongOpenHashMapWritableTest {
 
     value = m2.get(4);
     assertEquals(22L, value);
+
+    Int2LongOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test
@@ -176,6 +177,8 @@ public class Int2LongOpenHashMapWritableTest {
 
     value = m3.get(4);
     assertEquals(22L, value);
+
+    Int2LongOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test
@@ -281,6 +284,8 @@ public class Int2LongOpenHashMapWritableTest {
     assertEquals(9L, m1.get(1));
     assertEquals(22L, m1.get(2));
     assertEquals(5L, m1.get(3));
+
+    Int2LongOpenHashMapWritable.setLazyDecodeFlag(false);
   }
 
   @Test


### PR DESCRIPTION
Upgraded lintools-datatypes-fastutil to lintools-datatypes 1.1.1
Note that underlying fastutil artifacts are still very much out of date.
